### PR TITLE
Remove trailing whitespace in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This is a starting point for Go solutions to the
 
 In this challenge, you'll build a toy Redis clone that's capable of handling
 basic commands like `PING`, `SET` and `GET`. Along the way we'll learn about
-event loops, the Redis protocol and more. 
+event loops, the Redis protocol and more.
 
 **Note**: If you're viewing this repo on GitHub, head over to
 [codecrafters.io](https://codecrafters.io) to signup for early access.
@@ -15,12 +15,12 @@ event loops, the Redis protocol and more.
    `app/server.go`.
 1. Commit your changes and run `git push origin master` to submit your solution
    to CodeCrafters. Test output will be streamed to your terminal.
- 
+
 # Passing the first stage
 
 CodeCrafters runs tests when you do a `git push`. Make an empty commit and push
 your solution to see the first stage fail.
-   
+
 ``` sh
 git commit --allow-empty -m "Running tests"
 git push origin master
@@ -33,4 +33,3 @@ Go to `app/server.go` and uncomment the server implementation. Commit and
 push your changes, and you'll now see the first stage pass.
 
 Time to move on to the next stage!
-


### PR DESCRIPTION
The last line (line 35) had two trailing newlines, now it has 1, as is standard.